### PR TITLE
refactor genres api and add new languages (fr, es, it...)

### DIFF
--- a/pkg/api/discount_router_test.go
+++ b/pkg/api/discount_router_test.go
@@ -54,7 +54,7 @@ func (suite *DiscountRouterTestSuite) SetupTest() {
 		ID:             id,
 		InternalName:   "Test_game_2",
 		ReleaseDate:    time.Now(),
-		Genre:          pq.StringArray{},
+		GenreAddition:  pq.StringArray{},
 		Tags:           pq.StringArray{},
 		FeaturesCommon: pq.StringArray{},
 	}).Error

--- a/pkg/api/game/get_list.go
+++ b/pkg/api/game/get_list.go
@@ -32,32 +32,20 @@ func (api *Router) GetList(ctx echo.Context) error {
 		return err
 	}
 
-	all_genres, err := api.gameService.GetGenres(nil)
-	if err != nil {
-		return err
-	}
-
 	games, err := api.gameService.GetList(userId, vendorId, offset, limit, internalName, genre, releaseDate, sort, price)
 	if err != nil {
 		return err
 	}
 	dto := []ShortGameInfoDTO{}
 	for _, game := range games {
-		// Filter only game genres
-		genres := []GameTagDTO{}
-		for _, genre_id := range game.Genre {
-			for _, genre := range all_genres {
-				if genre.ID == genre_id {
-					genres = append(genres, GameTagDTO{Id: genre.ID, Title: genre.Title})
-					break
-				}
-			}
-		}
 		dto = append(dto, ShortGameInfoDTO{
 			ID:           game.ID,
 			InternalName: game.InternalName,
 			Icon:         "",
-			Genre:        genres,
+			Genres:       GameGenreDTO{
+				Main:       game.GenreMain,
+				Addition:   game.GenreAddition,
+			},
 			ReleaseDate:  game.ReleaseDate,
 			Prices:       GamePricesDTO{},
 		})

--- a/pkg/api/media_router_test.go
+++ b/pkg/api/media_router_test.go
@@ -53,7 +53,7 @@ func (suite *MediaRouterTestSuite) SetupTest() {
 		ID:             id,
 		InternalName:   "Test_game_1",
 		ReleaseDate:    time.Now(),
-		Genre:          pq.StringArray{},
+		GenreAddition:  pq.StringArray{},
 		Tags:           pq.StringArray{},
 		FeaturesCommon: pq.StringArray{},
 	}).Error

--- a/pkg/api/price_router_test.go
+++ b/pkg/api/price_router_test.go
@@ -64,7 +64,7 @@ func (suite *PriceRouterTestSuite) SetupTest() {
 		ID:             id,
 		InternalName:   "Test_game_2",
 		ReleaseDate:    time.Now(),
-		Genre:          pq.StringArray{},
+		GenreAddition:  pq.StringArray{},
 		Tags:           pq.StringArray{},
 		FeaturesCommon: pq.StringArray{},
 	}).Error

--- a/pkg/api/rating_router_test.go
+++ b/pkg/api/rating_router_test.go
@@ -61,7 +61,7 @@ func (suite *RatingRouterTestSuite) SetupTest() {
 		ID:             id,
 		InternalName:   "Test_game_2",
 		ReleaseDate:    time.Now(),
-		Genre:          pq.StringArray{},
+		GenreAddition:  pq.StringArray{},
 		Tags:           pq.StringArray{},
 		FeaturesCommon: pq.StringArray{},
 	}).Error

--- a/pkg/model/game.go
+++ b/pkg/model/game.go
@@ -34,13 +34,14 @@ type (
 		ReleaseDate          time.Time             `gorm:"type:timestamp; not null; default:now()"`
 		DisplayRemainingTime bool                  `gorm:"type:boolean; not null"`
 		AchievementOnProd    bool                  `gorm:"type:boolean; not null"`
-		FeaturesCommon       pq.StringArray        `gorm:"type:text[]; not null"`
+		FeaturesCommon       pq.StringArray        `gorm:"type:text[]; not null; default:array[]::text[]"`
 		FeaturesCtrl         string                `gorm:"type:text; not null"`
 		Platforms            game.Platforms        `gorm:"type:jsonb; not null; default:'{}'"`
 		Requirements         game.GameRequirements `gorm:"type:jsonb; not null; default:'{}'"`
 		Languages            game.GameLangs        `gorm:"type:jsonb; not null; default:'{}'"`
-		Genre                pq.StringArray        `gorm:"type:text[]; not null"`
-		Tags                 pq.StringArray        `gorm:"type:text[]; not null"`
+		GenreMain            string                `gorm:"type:text; not null; default:''"`
+		GenreAddition        pq.StringArray        `gorm:"type:text[]; not null; default:array[]::text[]"`
+		Tags                 pq.StringArray        `gorm:"type:text[]; not null; default:array[]::text[]"`
 
 		Vendor    *Vendor   /// VendorID is foreignKey for Vendor
 		VendorID  uuid.UUID `gorm:"type:uuid"`

--- a/pkg/model/utils/localized_string.go
+++ b/pkg/model/utils/localized_string.go
@@ -12,7 +12,14 @@ type LocalizedString struct {
 	EN string `json:"en"`
 
 	// russian name
-	RU string `json:"ru"`
+	RU string `json:"ru,omitempty"`
+
+	// other languages
+	FR string `json:"fr,omitempty"`
+	ES string `json:"es,omitempty"`
+	DE string `json:"de,omitempty"`
+	IT string `json:"it,omitempty"`
+	PT string `json:"pt,omitempty"`
 }
 
 func (p LocalizedString) Value() (driver.Value, error) {

--- a/pkg/model/utils/localized_string_array.go
+++ b/pkg/model/utils/localized_string_array.go
@@ -12,7 +12,14 @@ type LocalizedStringArray struct {
 	EN []string `json:"en"`
 
 	// russian name
-	RU []string `json:"ru"`
+	RU []string `json:"ru,omitempty"`
+
+	// other languages
+	FR []string `json:"fr,omitempty"`
+	ES []string `json:"es,omitempty"`
+	DE []string `json:"de,omitempty"`
+	IT []string `json:"it,omitempty"`
+	PT []string `json:"pt,omitempty"`
 }
 
 func (p LocalizedStringArray) Value() (driver.Value, error) {

--- a/pkg/orm/discount_service_test.go
+++ b/pkg/orm/discount_service_test.go
@@ -91,7 +91,8 @@ func (suite *DiscountServiceTestSuite) SetupTest() {
 	game.Requirements = bto.GameRequirements{}
 	game.Languages = bto.GameLangs{}
 	game.FeaturesCommon = []string{}
-	game.Genre = []string{}
+	game.GenreMain = ""
+	game.GenreAddition = []string{}
 	game.Tags = []string{}
 	game.VendorID = vendor.ID
 	game.CreatorID = userId

--- a/pkg/orm/media_service_test.go
+++ b/pkg/orm/media_service_test.go
@@ -44,7 +44,7 @@ func (suite *MediaServiceTestSuite) SetupTest() {
 		ID:             id,
 		InternalName:   "Test_game_3",
 		ReleaseDate:    time.Now(),
-		Genre:          pq.StringArray{},
+		GenreAddition:  pq.StringArray{},
 		Tags:           pq.StringArray{},
 		FeaturesCommon: pq.StringArray{},
 	}).Error

--- a/pkg/orm/onboarding_service_test.go
+++ b/pkg/orm/onboarding_service_test.go
@@ -49,7 +49,7 @@ func (suite *OnbardingServiceTestSuite) SetupTest() {
 		ID:             id,
 		InternalName:   "Test_game_3",
 		ReleaseDate:    time.Now(),
-		Genre:          pq.StringArray{},
+		GenreAddition:  pq.StringArray{},
 		Tags:           pq.StringArray{},
 		FeaturesCommon: pq.StringArray{},
 		VendorID:		id,

--- a/pkg/orm/price_service_test.go
+++ b/pkg/orm/price_service_test.go
@@ -45,7 +45,7 @@ func (suite *PriceServiceTestSuite) SetupTest() {
 		ID:             id,
 		InternalName:   "Test_game_2",
 		ReleaseDate:    time.Now(),
-		Genre:          pq.StringArray{},
+		GenreAddition:  pq.StringArray{},
 		Tags:           pq.StringArray{},
 		FeaturesCommon: pq.StringArray{},
 	}).Error

--- a/pkg/orm/rating_service_test.go
+++ b/pkg/orm/rating_service_test.go
@@ -59,7 +59,7 @@ func (suite *RatingServiceTestSuite) SetupTest() {
 		ID:             id,
 		InternalName:   "Test_game_2",
 		ReleaseDate:    time.Now(),
-		Genre:          pq.StringArray{},
+		GenreAddition:  pq.StringArray{},
 		Tags:           pq.StringArray{},
 		FeaturesCommon: pq.StringArray{},
 	}).Error

--- a/pkg/orm/utils/utils_test.go
+++ b/pkg/orm/utils/utils_test.go
@@ -22,7 +22,7 @@ func TestCheckExists(t *testing.T) {
 	_ = db.DropAllTables()
 	db.Init()
 
-	game := &model.Game{ID: uuid.NewV4(), Tags: []string{"1", "2"}, Genre: []string{"1", "2"}, FeaturesCommon: []string {"1", "2"}, VendorID: uuid.NewV4(), CreatorID: uuid.NewV4(), Title: "asd"}
+	game := &model.Game{ID: uuid.NewV4(), Tags: []string{"1", "2"}, GenreMain: "1", GenreAddition: []string{"2"}, FeaturesCommon: []string {"1", "2"}, VendorID: uuid.NewV4(), CreatorID: uuid.NewV4(), Title: "asd"}
 	err = db.DB().Create(game).Error
 	if err != nil {
 		t.FailNow()

--- a/spec/dashboard/games_openapi.yaml
+++ b/spec/dashboard/games_openapi.yaml
@@ -2016,6 +2016,16 @@ components:
             en: multiplayer
             ru: мультиплеер
 
+    GameGenres:
+      type: object
+      properties:
+        main:
+          type: string
+        addition:
+          type: array
+          items:
+            type: string
+
     Genre:
       type: object
       properties:
@@ -2116,10 +2126,8 @@ components:
         icon:
           type: "string"
           readOnly: true
-        genre:
-          type: "array"
-          items:
-            $ref: "#/components/schemas/Genre"
+        genres:
+          $ref: '#/components/schemas/GameGenres'
           readOnly: true
         releaseDate:
           type: "string"
@@ -2201,26 +2209,22 @@ components:
         - $ref: '#/components/schemas/BaseGame'
         - type: object
           properties:
-            genre:
-              type: "array"
-              items:
-                $ref: "#/components/schemas/Genre"
+            genres:
+              $ref: '#/components/schemas/GameGenres'
             tags:
-              type: "array"
+              type: array
               items:
-                $ref: "#/components/schemas/Tag"
+                type: string
 
     ChangeGame:
       allOf:
         - $ref: '#/components/schemas/BaseGame'
         - type: object
           properties:
-            genre:
-              type: "array"
-              items:
-                type: string
+            genres:
+              $ref: '#/components/schemas/GameGenres'
             tags:
-              type: "array"
+              type: array
               items:
                 type: string
 


### PR DESCRIPTION
Поменял структуру жанров и тегов в игре get & put на такого вида: 
genres: {
    main: 'main id',
    addition: ['additional id 1', 'additional id 2']
}
Добавил стандартные языки локализации в модель